### PR TITLE
Adds information about the public dataset bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Alternatively, it can be configured with an external PostgreSQL database connect
 juju config finos-waltz-k8s db-host="<db-host>" db-port="<db-port>" db-name="<db-name>" db-username="<db-username>" db-password="<db-password>"
 ```
 
-For an in-depth guide on how to deploy Waltz in a local environment from scratch, see the [Local deployment guide](doc/LocalDeployment.md).
+For an in-depth guide on how to deploy the Waltz charm or the Waltz bundle in a local environment from scratch, see the [Local deployment guide](doc/LocalDeployment.md).
 
 ## Relations
 

--- a/docs/LocalDeployment.md
+++ b/docs/LocalDeployment.md
@@ -43,6 +43,14 @@ juju deploy --trust finos-waltz-bundle --channel=edge
 
 The bundle contains the following charms: ``finos-waltz-k8s``, ``postgresql-k8s``, and ``nginx-ingress-integrator``. The bundle also creates creates relations between the ``finos-waltz-k8s`` charm and the ``postgresql-k8s`` and ``nginx-ingress-integrator`` charms.
 
+Alternatively, you can deploy a demo bundle containing a public dataset injected into the Waltz database for testing purposes:
+
+```bash
+juju deploy --trust finos-waltz-bundle --channel=public/edge
+```
+
+This demo bundle also contains a ``postgresql-data-k8s`` charm which is configured with a [PostgreSQL database dump](https://github.com/finos/waltz/files/8390039/postgres-dump-1.40.sql.gz), which will be injected periodically into the Waltz database in the related ``postgresql-k8s`` charm.
+
 In another terminal, you can check the deployment status and the integration code running using `watch --color juju status --color`. All the charms should become Active after a few minutes.
 
 The FINOS Waltz charm will use the PostgreSQL database provisioned by the ``postgresql-k8s`` charm. Alternatively, you can configure it with an external PostgreSQL connection details:


### PR DESCRIPTION
The bundle published under the ``--channel=public/edge`` also contains a ``postgresql-data-k8s`` charm, which is configured with a PostgreSQL database dump containing a test dataset meant for testing purposes. This bundle can be used for trying out Waltz.

This commit adds information about in the documentation.