### PR TITLE
Fixes integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: claudiubelu/actions-operator@main
         with:
           provider: microk8s
+          microk8s-addons: "storage dns rbac ingress"
 
       - name: Run integration tests
         run: tox -vve integration

--- a/tox.ini
+++ b/tox.ini
@@ -64,12 +64,14 @@ commands =
       -m pytest -v --tb native {posargs} {[vars]tst_path}unit
     coverage report
 
+# NOTE: pytest-operator has been constrained due to the following:
+# https://github.com/charmed-kubernetes/pytest-operator/issues/72
 [testenv:integration]
 description = Run integration tests
 deps =
     pytest
     juju
-    pytest-operator
+    pytest-operator<0.17.0
     tenacity
     requests
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
The ingress microk8s addon needs to be added in order for the ingress-related tests to pass.