### PR TITLE
integration: Removes the pytest-operator requirement restriction

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,14 +64,12 @@ commands =
       -m pytest -v --tb native {posargs} {[vars]tst_path}unit
     coverage report
 
-# NOTE: pytest-operator has been constrained due to the following:
-# https://github.com/charmed-kubernetes/pytest-operator/issues/72
 [testenv:integration]
 description = Run integration tests
 deps =
     pytest
     juju
-    pytest-operator<0.17.0
+    pytest-operator
     tenacity
     requests
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Currently, the integration tests are failing. Removing the ``pytest-operator`` requirement will fix the issue.

The issue because of which the restriction was introduced was resolved in ``pytest-operator`` 0.18.0