### PR TITLE
Adds additional logging to the renew_certificate action

### DIFF
--- a/.github/workflows/renew_certificate.yaml
+++ b/.github/workflows/renew_certificate.yaml
@@ -24,7 +24,9 @@ jobs:
             juju status --relations
 
             # Run the renew action on the certbot-k8s charm.
+            echo "Running renew-certificate action..."
             action_result=$(juju run-action certbot-k8s/0 renew-certificate --wait)
+            echo "The renew-certificate action finished with the result: ${action_result}"
 
             if [[ $action_result != *"status: completed"* ]]; then
               echo "Certificate renewal failed:\n$action_result" 


### PR DESCRIPTION
Additional logging can make it easier to debug whether the action ran as intended or not.