### PR TITLE
actions: Updates juju run-action to juju run

### DIFF
--- a/.github/workflows/renew_certificate.yaml
+++ b/.github/workflows/renew_certificate.yaml
@@ -25,7 +25,7 @@ jobs:
 
             # Run the renew action on the certbot-k8s charm.
             echo "Running renew-certificate action..."
-            action_result=$(juju run-action certbot-k8s/0 renew-certificate --wait)
+            action_result=$(juju run certbot-k8s/0 renew-certificate --wait)
             echo "The renew-certificate action finished with the result: ${action_result}"
 
             if [[ $action_result != *"status: completed"* ]]; then


### PR DESCRIPTION
Starting with juju v3.0.0, juju run should be used of juju run-action. [1]

[1] https://juju.is/docs/olm/manage-actions#heading--run-an-action