### PR TITLE
Switches Public Instance controller to the newer one

### DIFF
--- a/.github/workflows/refresh_deployment.yaml
+++ b/.github/workflows/refresh_deployment.yaml
@@ -20,6 +20,9 @@ jobs:
           script: |
             set -x
 
+            # Controller name is "waltz-public-v3", model name is "waltz-model-v3"
+            juju switch waltz-public-v3:waltz-model-v3
+
             # Running juju status will show us the current revisions of the charms.
             juju status --relations
 

--- a/.github/workflows/renew_certificate.yaml
+++ b/.github/workflows/renew_certificate.yaml
@@ -18,7 +18,8 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script: |
-            juju switch waltz-public-controller:waltz-public-model
+            # Controller name is "waltz-public-v3", model name is "waltz-model-v3"
+            juju switch waltz-public-v3:waltz-model-v3
                     
             # Running juju status will show us the current revisions of the charms.
             juju status --relations


### PR DESCRIPTION
The FINOS Waltz instance has been migrated to a Juju v3.0.2 controller.