### PR TITLE
integration tests: Various updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,10 +39,7 @@ jobs:
         run: python -m pip install tox
 
       - name: Setup operator environment
-        # TODO: change this to charmed-kubernetes/actions-operator@main once
-        # the following issue is addressed:
-        # https://github.com/charmed-kubernetes/actions-operator/issues/32
-        uses: claudiubelu/actions-operator@main
+        uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
           microk8s-addons: "storage dns rbac ingress"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -25,7 +25,7 @@ NGINX_INGRESS_CHARM = "nginx-ingress-integrator"
 # Similarly, when the Ingress Route is being established, it takes a few seconds to take effect.
 @tenacity.retry(
     retry=tenacity.retry_if_result(lambda x: x is False),
-    stop=tenacity.stop_after_attempt(5),
+    stop=tenacity.stop_after_attempt(15),
     wait=tenacity.wait_exponential(multiplier=1, min=5, max=30),
 )
 def check_waltz_connection(url, headers=None):
@@ -52,7 +52,12 @@ async def test_build_and_deploy(ops_test: pytest_plugin.OpsTest):
     # build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
     resources = {"waltz-image": METADATA["resources"]["waltz-image"]["upstream-source"]}
-    await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME)
+    await ops_test.model.deploy(
+        charm,
+        series="focal",
+        resources=resources,
+        application_name=APP_NAME,
+    )
 
     # Deploy the needed postgresql-k8s charm and relate it to the waltz charm.
     await ops_test.model.deploy(POSTGRESQL_CHARM)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -41,6 +41,7 @@ class TestCharm(unittest.TestCase):
     def test_database_relation(self):
         """Test for the PostgreSQL relation."""
         # Setup mocks and start the initial hooks.
+        self.harness.begin_with_initial_hooks()
         container = self.harness.model.unit.get_container("waltz")
         self._patch(container, "stop")
         mock_can_connect = self._patch(container, "can_connect")
@@ -48,7 +49,6 @@ class TestCharm(unittest.TestCase):
 
         # Setting the leader will allow the PostgreSQL charm to write relation data.
         self.harness.set_leader(True)
-        self.harness.begin_with_initial_hooks()
 
         # Update the charm config, the charm should become Active.
         self.harness.update_config({"db-host": "foo.lish"})
@@ -92,13 +92,13 @@ class TestCharm(unittest.TestCase):
 
     def test_waltz_pebble_ready(self):
         # Check the initial Pebble plan is empty
+        self.harness.begin_with_initial_hooks()
         initial_plan = self.harness.get_container_pebble_plan("waltz")
         self.assertEqual(initial_plan.to_yaml(), "{}\n")
 
         # Get the waltz container from the model and emit the PebbleReadyEvent carrying it.
         container = self.harness.model.unit.get_container("waltz")
         mock_stop = self._patch(container, "stop")
-        self.harness.begin_with_initial_hooks()
         self.harness.charm.on.waltz_pebble_ready.emit(container)
 
         # No datebase host was configured, so the status should be Blocked.


### PR DESCRIPTION
Switches to ``charmed-kubernetes/actions-operator@main``, which now has support for ``microk8s-addons`` option.

Increases the connectivity check timeout as it can be a bit too short for nodes with fewer resources.