### PR TITLE
Pins integration test requirements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,14 +66,16 @@ commands =
       -m pytest -v --tb native {posargs} {[vars]tst_path}unit
     coverage report
 
+# NOTE: The integration tests will spawn a Juju v2.9 controller,
+# and Juju v3.1 client does not support it.
 [testenv:integration]
 description = Run integration tests
 deps =
     pytest
-    juju
-    pytest-operator
-    tenacity
-    requests
+    juju < 3.1.0
+    pytest-operator < 0.24.0
+    tenacity < 8.3.0
+    requests < 2.29.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
The integration tests will spawn a Juju v2.9 controller, and Juju v3.1 client does not support it.

Pins other requirements for the integration tests.