### PR TITLE
Pins pytest version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    pytest
+    pytest < 7.3.0
     juju < 3.1.0
     pytest-operator < 0.24.0
     tenacity < 8.3.0


### PR DESCRIPTION
``TempPathFactory`` in the latest ``pytest`` version (7.3.0) now requires positional arguments, which are not passed by the current ``pytest-operator``. This causes the integration tests to fail.
