### PR TITLE
integration: Switches juju to 3.1 for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,8 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          juju-channel: 3.1/stable
+          channel: 1.27-strict/stable
           microk8s-addons: "storage dns rbac ingress"
 
       - name: Run integration tests

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 POSTGRESQL_CHARM = "postgresql-k8s"
+POSTGRESQL_CHARM_CHANNEL = "14/stable"
 NGINX_INGRESS_CHARM = "nginx-ingress-integrator"
 
 
@@ -60,7 +61,7 @@ async def test_build_and_deploy(ops_test: pytest_plugin.OpsTest):
     )
 
     # Deploy the needed postgresql-k8s charm and relate it to the waltz charm.
-    await ops_test.model.deploy(POSTGRESQL_CHARM)
+    await ops_test.model.deploy(POSTGRESQL_CHARM, channel=POSTGRESQL_CHARM_CHANNEL)
 
     # issuing dummy update_status just to trigger an event
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
 description = Run integration tests
 deps =
     pytest < 7.3.0
-    juju < 3.1.0
+    juju < 3.2.0
     pytest-operator < 0.24.0
     tenacity < 8.3.0
     requests < 2.29.0


### PR DESCRIPTION
The latest release of the ``postgresql-k8s`` charm is supported by juju 3.0 or newer. The ``charmed-kubernetes/actions-operator@main`` action install juju 2.9 by default.

Additionally, switches ``microk8s`` version to ``1.27-strict/stable``, as juju 3.0 and newer requires ``microk8s`` to be strictly confined.

Updated the Python juju dependency.