### PR TITLE
actions: Removing the explicit controller name

### DIFF
--- a/.github/workflows/refresh_deployment.yaml
+++ b/.github/workflows/refresh_deployment.yaml
@@ -20,8 +20,8 @@ jobs:
           script: |
             set -x
 
-            # Controller name is "waltz-public-v3", model name is "waltz-model-v3"
-            juju switch waltz-public-v3:waltz-model-v3
+            # The model name is "waltz-model-v3"
+            juju switch waltz-model-v3
 
             # Running juju status will show us the current revisions of the charms.
             juju status --relations

--- a/.github/workflows/renew_certificate.yaml
+++ b/.github/workflows/renew_certificate.yaml
@@ -18,8 +18,8 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script: |
-            # Controller name is "waltz-public-v3", model name is "waltz-model-v3"
-            juju switch waltz-public-v3:waltz-model-v3
+            # The model name is "waltz-model-v3"
+            juju switch waltz-model-v3
                     
             # Running juju status will show us the current revisions of the charms.
             juju status --relations


### PR DESCRIPTION
The demo environment was updated from juju 3.0 to 3.1. For this, a new controller had to be bootstrapped, and the waltz-public-v3 model was migrated to it.

Since we only have one controller, we don't need to explicitly specify it. This will make it easier in the future, when upgrading the controller once again.