### PR TITLE
#45 EC2 Deployment Postgres image

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ juju relate postgresql-k8s:db finos-waltz-k8s:db
 
 ## OCI Images
 
-This charm requires the Waltz docker image: ``ghcr.io/finos/waltz``.
+This charm requires the Waltz docker image: ``ghcr.io/finos/waltz:postgres``.
 
 ## FINOS Waltz Charm and Bundle release automation process
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -32,7 +32,7 @@ If there are any other issues, ``charmcraft clean`` might help.
 After the charm has been built, you will be able to find it in the local folder. You can then deploy it with the command:
 
 ```bash
-juju deploy ./finos-waltz-k8s_ubuntu-20.04-amd64.charm --resource waltz-image=ghcr.io/finos/waltz
+juju deploy ./finos-waltz-k8s_ubuntu-20.04-amd64.charm --resource waltz-image=ghcr.io/finos/waltz:postgres
 ```
 
 If it was already deployed, you can simply refresh it:

--- a/docs/working_sessions/session2_charmcraft.md
+++ b/docs/working_sessions/session2_charmcraft.md
@@ -174,7 +174,7 @@ juju config sample-operator thing=foo
 
 Waltz
 ``` bash
-juju deploy ./waltz-operator_ubuntu-20.04-amd64.charm --resource waltz-image=ghcr.io/finos/waltz
+juju deploy ./waltz-operator_ubuntu-20.04-amd64.charm --resource waltz-image=ghcr.io/finos/waltz:postgres
 juju status
 
 juju config waltz-operator waltz-db-host="10.37.24.1"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,5 +27,5 @@ containers:
 resources:
   waltz-image:
     type: oci-image
-    description: OCI image for waltz (ghcr.io/finos/waltz)
-    upstream-source: ghcr.io/finos/waltz
+    description: OCI image for waltz (ghcr.io/finos/waltz:postgres)
+    upstream-source: ghcr.io/finos/waltz:postgres


### PR DESCRIPTION
Hi guys,

Not sure who is supposed to review these PRs.  The issue is that there is now a postgres and mssql build from 1.80, unfortunately the latest is now mssql.  

So making the config for this runner as the ghcr.io/finos/waltz:**postgres** version.

Should get the demo site up and running again.

refer to here for the latest images - https://github.com/finos/waltz/pkgs/container/waltz